### PR TITLE
修复：Star History 图表改用新地址

### DIFF
--- a/README.md
+++ b/README.md
@@ -2738,4 +2738,4 @@ UnifiedPush 是一套可以让用户选择推送通知方式的规范和工具�
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=xlucn/oh-my-foss-android&type=Timeline)](https://star-history.com/#xlucn/oh-my-foss-android&Timeline)
+[![Star History Chart](https://star-history.dera.page/svg?repos=xlucn/oh-my-foss-android&type=Timeline)](https://star-history.dera.page/#xlucn/oh-my-foss-android&Timeline)


### PR DESCRIPTION
当前 README 中的 Star History 图表已失效，原因是 GitHub 对 stargazer API 的访问限制。本次修改将图表切换到一个不受此限制的新数据源，使图表恢复正常显示。